### PR TITLE
[backend] Add ENABLE_EMAIL_NOTIFICATIONS flag to env var

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -25,6 +25,8 @@ _*For quick start, copy the `template.env` file to `.env`. The values given in `
 | MAILER_SENDER_EMAIL        | Email address for sending emails                                                               |
 | MAILER_SENDER_PASS         | Password for authenticating with SMTP Host                                                     |
 | MAILER_HOST                | SMTP Host supporting TLS which will send our emails                                            |
+| DEBUG                      | Enable debugging mode - disables some features and enables debugging features (dev only)       |
+| ENABLE_EMAIL_NOTIFICATIONS | Set this flag to enable emails to be sent, if set to false emails will not be sent,default true|
 
 
 ### Cors and Cookies

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -24,6 +24,7 @@ export const appConfig = {
   },
 
   debug: fromEnv('DEBUG', 'false').toLowerCase() === 'true',
+  enableMail: fromEnv('ENABLE_EMAIL_NOTIFICATIONS', 'true').toLowerCase() === 'true',
 };
 
 console.log(appConfig);

--- a/server/template.env
+++ b/server/template.env
@@ -16,3 +16,9 @@ CORS_ALLOWED_ORIGINS=http://localhost:5501/,http://localhost:8000/,http://127.0.
 MAILER_SENDER_EMAIL=noreply@codegasms.com
 MAILER_SENDER_PASS=
 MAILER_HOST=smtppro.zoho.in
+
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+DEBUG=True
+ENABLE_EMAIL_NOTIFICATIONS=False


### PR DESCRIPTION
Add ENABLE_EMAIL_NOTIFICATIONS flag to env var to enable/disable email sending feature (dev mode feature)

 - [x] Add ENABLE_EMAIL_NOTIFICATIONS to template.env and README.md.
 - [x] ENABLE_EMAIL_NOTIFICATIONS is set to true by default if not set.
 - [x] login/registration mails to be sent based on the ENABLE_EMAIL_NOTIFICATIONS flag.

closes #106 